### PR TITLE
Add --short flag to zip code.

### DIFF
--- a/cmd/gofaker/main.go
+++ b/cmd/gofaker/main.go
@@ -42,7 +42,7 @@ Usage:
 	gofaker now [--fmt=<fmt>]
 	gofaker password [<min> <max>]
 	gofaker phone [--short]
-	gofaker (postal-code|zip) [--state=<state>]
+	gofaker (postal-code|zip) [--short] [--state=<state>]
 	gofaker sex [--short] [--lower]
 	gofaker state [--short] [-n <val,>]
 	gofaker street

--- a/handler.go
+++ b/handler.go
@@ -124,7 +124,11 @@ func HandleAddress(opts map[string]interface{}) string {
 		if opts["--state"] != nil {
 			faker.Address().PostcodeByState(opts["--state"].(string))
 		}
-		return faker.Address().Postcode()
+		zip := faker.Address().Postcode()
+		if Short {
+			zip = zip[:5]
+		}
+		return zip
 	}
 	return faker.Address().String()
 }


### PR DESCRIPTION
Limits zip codes to 5 digits.